### PR TITLE
Removed ASMV & ASMINF from Release

### DIFF
--- a/Zlib.autopkg
+++ b/Zlib.autopkg
@@ -11,7 +11,7 @@ nuget
    nuspec
    {
       id = zlib-tsc-package;
-      version: 1.2.11;
+      version: 1.2.11.1;
       title: zlib compression library;
       authors: { TechSmith Corporation, Jean-loup Gailly, Mark Adler };
       owners: { TechSmith Corporation };

--- a/contrib/vstudio/vc14/zlibstat.vcxproj
+++ b/contrib/vstudio/vc14/zlibstat.vcxproj
@@ -198,7 +198,7 @@
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>..\..\..;..\..\masmx86;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_WARNINGS;ASMV;ASMINF;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>
       </ExceptionHandling>
@@ -315,7 +315,7 @@
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>..\..\..;..\..\masmx86;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_WARNINGS;ASMV;ASMINF;WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_WARNINGS;WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>
       </ExceptionHandling>


### PR DESCRIPTION
The project was defined with ASMV & ASMINF on Release configuration.  It was not recommended to use by the original zlib author.  [Read this](https://github.com/madler/zlib/issues/200#issuecomment-272937236)