### PR TITLE
Include minizip's headers in the nuget pkg

### DIFF
--- a/Zlib.autopkg
+++ b/Zlib.autopkg
@@ -33,7 +33,8 @@ nuget
 
    files
    {
-      nestedInclude: { #destination=${d_include}Zlib; *.h };
+      nested2Include: { #destination=${d_include}Zlib; "*.h" };
+      nested1Include: { #destination=${d_include}Zlib\contrib\minizip; "contrib\minizip\*.h" };
       libpdb:        { #destination=${d_lib}; };
       ("Win32", "v141", "Debug,Release") =>
       {

--- a/Zlib.autopkg
+++ b/Zlib.autopkg
@@ -11,7 +11,7 @@ nuget
    nuspec
    {
       id = zlib-tsc-package;
-      version: 1.2.11.2;
+      version: 1.2.11.3;
       title: zlib compression library;
       authors: { TechSmith Corporation, Jean-loup Gailly, Mark Adler };
       owners: { TechSmith Corporation };
@@ -22,10 +22,13 @@ nuget
       summary: @"Zlib Compression Library for use in TechSmith products";
       description: @"Zlib is a compression library written in C.
          New features:
-         Breaking changes:
          Bug fixes:
-         Misc:
-            - Updated toolset to v141 for Visual Studio 2017
+         Breaking changes:
+         Changes:
+            - 1.2.11.3 Include contrib/minizip header files
+            - 1.2.11.2 Updated toolset to v141 for Visual Studio 2017
+            - 1.2.11.1 Removed ASMV & ASMINF from Release 
+            - 1.2.11   Initial version
          ";
       copyright: @"Copyright (c) 2018.";
       tags: { zlib, CoApp, compression, vs2017, native };

--- a/contrib/minizip/ioapi.h
+++ b/contrib/minizip/ioapi.h
@@ -43,7 +43,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "zlib.h"
+#include "../../zlib.h"
 
 #if defined(USE_FILE32API)
 #define fopen64 fopen

--- a/contrib/minizip/mztools.h
+++ b/contrib/minizip/mztools.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 #ifndef _ZLIB_H
-#include "zlib.h"
+#include "../../zlib.h"
 #endif
 
 #include "unzip.h"

--- a/contrib/minizip/unzip.h
+++ b/contrib/minizip/unzip.h
@@ -48,7 +48,7 @@ extern "C" {
 #endif
 
 #ifndef _ZLIB_H
-#include "zlib.h"
+#include "../../zlib.h"
 #endif
 
 #ifndef  _ZLIBIOAPI_H

--- a/contrib/minizip/zip.h
+++ b/contrib/minizip/zip.h
@@ -47,7 +47,7 @@ extern "C" {
 //#define HAVE_BZIP2
 
 #ifndef _ZLIB_H
-#include "zlib.h"
+#include "../../zlib.h"
 #endif
 
 #ifndef _ZLIBIOAPI_H


### PR DESCRIPTION
* make minizip's headers available to consumers of the zlib nuget pkg
* add param iMatchJustFileName to unzLocateFile ()